### PR TITLE
ADD DB2 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.ibm.db2</groupId>
+      <artifactId>jcc</artifactId>
+      <version>11.5.6.0</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/io/ebean/docker/commands/Db2Config.java
+++ b/src/main/java/io/ebean/docker/commands/Db2Config.java
@@ -1,0 +1,74 @@
+package io.ebean.docker.commands;
+
+import java.util.Properties;
+
+public class Db2Config extends DbConfig {
+
+  private String createOptions;
+  private String configOptions;
+
+  public Db2Config(String version, Properties properties) {
+    this(version);
+    setProperties(properties);
+  }
+
+  public Db2Config(String version) {
+    super("db2", 50000, 50000, version);
+    this.image = "ibmcom/db2:" + version;
+    this.setTmpfs("/database:rw");
+  }
+
+  /**
+   * Expose for MariaDB config.
+   */
+  protected Db2Config(String platform, int port, int internalPort, String version) {
+    super(platform, port, internalPort, version);
+  }
+
+  @Override
+  public String jdbcUrl() {
+    return "jdbc:db2://localhost:" + getPort() + "/" + getDbName();
+  }
+
+  public String getCreateOptions() {
+    return createOptions;
+  }
+
+  /**
+   * Sets additional create options specified in
+   * https://www.ibm.com/docs/en/db2/11.5?topic=commands-create-database Example:
+   * 'USING CODESET UTF-8 TERRITORY DE COLLATE USING IDENTITY PAGESIZE 32768'
+   */
+public void setCreateOptions(String createOptions) {
+  this.createOptions = createOptions;
+}
+
+  public String getConfigOptions() {
+    return configOptions;
+  }
+
+  /**
+   * Sets DB2 config options. See
+   * https://www.ibm.com/docs/en/db2/11.5?topic=commands-update-database-configuration
+   * for details Example 'USING STRING_UNITS CODEUNITS32
+   * 
+   * @param db2ConfigOptions
+   */
+  public void setConfigOptions(String configOptions) {
+    this.configOptions = configOptions;
+  }
+
+  /**
+   * Load configuration from properties.
+   */
+  public DbConfig setProperties(Properties properties) {
+    if (properties == null) {
+      return this;
+    }
+    super.setProperties(properties);
+    createOptions = prop(properties, "createOptions", createOptions);
+    configOptions = prop(properties, "configOptions", configOptions);
+    return this;
+  }
+
+}

--- a/src/main/java/io/ebean/docker/commands/Db2Config.java
+++ b/src/main/java/io/ebean/docker/commands/Db2Config.java
@@ -39,9 +39,9 @@ public class Db2Config extends DbConfig {
    * https://www.ibm.com/docs/en/db2/11.5?topic=commands-create-database Example:
    * 'USING CODESET UTF-8 TERRITORY DE COLLATE USING IDENTITY PAGESIZE 32768'
    */
-public void setCreateOptions(String createOptions) {
-  this.createOptions = createOptions;
-}
+  public void setCreateOptions(String createOptions) {
+    this.createOptions = createOptions;
+  }
 
   public String getConfigOptions() {
     return configOptions;
@@ -51,8 +51,6 @@ public void setCreateOptions(String createOptions) {
    * Sets DB2 config options. See
    * https://www.ibm.com/docs/en/db2/11.5?topic=commands-update-database-configuration
    * for details Example 'USING STRING_UNITS CODEUNITS32
-   * 
-   * @param db2ConfigOptions
    */
   public void setConfigOptions(String configOptions) {
     this.configOptions = configOptions;

--- a/src/main/java/io/ebean/docker/commands/Db2Container.java
+++ b/src/main/java/io/ebean/docker/commands/Db2Container.java
@@ -1,0 +1,151 @@
+package io.ebean.docker.commands;
+
+import io.ebean.docker.commands.process.ProcessHandler;
+import io.ebean.docker.commands.process.ProcessResult;
+import io.ebean.docker.container.Container;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Commands for controlling a DB2 docker container.
+ */
+public class Db2Container extends JdbcBaseDbContainer implements Container {
+
+  public static Db2Container create(String Db2Version, Properties properties) {
+    return new Db2Container(new Db2Config(Db2Version, properties));
+  }
+
+  public Db2Container(Db2Config config) {
+    super(config);
+  }
+
+  @Override
+  void createDatabase() {
+    if (checkConnectivity(false)) {
+      return; // container with DB & userName already running - do not recreate DB
+    }
+    // #1 Do user management (as root)
+    try {
+      dockerSu("root", "useradd -g db2iadm1 " + dbConfig.getUsername());
+    } catch (CommandException e) {
+      e.getResult().getOutLines().forEach(log::warn);
+    }
+    dockerSu("root", "echo \"" + dbConfig.getUsername() + ":" + dbConfig.getPassword() + "\" | chpasswd");
+
+    // #2 create database (with optional create options)
+    String cmd = "db2 create database " + dbConfig.getDbName();
+    if (defined(((Db2Config) dbConfig).getCreateOptions())) {
+      cmd = cmd + " " + ((Db2Config) dbConfig).getCreateOptions();
+    }
+    dockerSu(cmd);
+
+    // #3 set optional config options
+    if (defined(((Db2Config) dbConfig).getConfigOptions())) {
+      cmd = "db2 update database config for " + dbConfig.getDbName() + " " + ((Db2Config) dbConfig).getConfigOptions();
+      dockerSu(dbConfig.getAdminUsername(), cmd);
+    }
+
+    // #4 activate database
+    cmd = "db2 activate database " + dbConfig.getDbName();
+    dockerSu(cmd);
+
+    // #5 set recommended values for database
+    cmd = "/var/db2_setup/lib/set_rec_values.sh " + dbConfig.getDbName();
+    dockerSu(cmd);
+  }
+
+  @Override
+  void dropCreateDatabase() {
+    try {
+      dockerSu("db2 drop database " + dbConfig.getDbName());
+    } catch (CommandException e) {
+      // may fail, if database does not exist
+      e.getResult().getOutLines().forEach(log::warn);
+    }
+    createDatabase();
+  }
+
+  @Override
+  protected ProcessBuilder runProcess() {
+
+    List<String> args = dockerRun();
+    args.add("--privileged"); // this container needs extended permissions
+    args.add("-e");
+    args.add("LICENSE=accept");
+
+    args.add("-e");
+    args.add("SAMPLEDB=false");
+
+    args.add("-e");
+    args.add("ARCHIVE_LOGS=false");
+    // (default: true) Specify false to not configure log archiving (reduces start
+    // up time)
+
+    args.add("-e");
+    args.add("AUTOCONFIG=false");
+    // (default: true) Specify false to not run auto configuration on the instance
+    // and database (reduces start up time)
+
+    // set admin user & pw - but do not create a database
+    args.add("-e");
+    args.add("DB2INSTANCE=" + dbConfig.getAdminUsername());
+
+    if (defined(dbConfig.getAdminPassword())) {
+      args.add("-e");
+      args.add("DB2INST1_PASSWORD=" + dbConfig.getAdminPassword());
+    }
+    args.add("-e");
+    args.add("DBNAME=");
+    args.add(config.getImage());
+    return createProcessBuilder(args);
+  }
+
+  /**
+   * Runs the given (linux) command inside the container as given user.
+   */
+  protected List<String> dockerSu(String user, String cmd) {
+    List<String> args = new ArrayList<>();
+    args.add(config.docker);
+    args.add("exec");
+    args.add("-i");
+    args.add(config.containerName());
+    args.add("su");
+    args.add("-");
+    args.add(user);
+    args.add("-c");
+    args.add(cmd);
+    ProcessBuilder pb = createProcessBuilder(args);
+    ProcessResult pr = ProcessHandler.process(pb);
+    pr.getOutLines().forEach(log::debug);
+    return pr.getOutLines();
+  }
+
+  /**
+   * Executes the (linux) command as DB-admin user.
+   */
+  protected List<String> dockerSu(String cmd) {
+    return dockerSu(dbConfig.getAdminUsername(), cmd);
+  }
+
+  /**
+   * used to detect, when the container is up. This does not mean, you can already
+   * connect with JDBC. You must create the database first.
+   */
+  @Override
+  boolean checkConnectivity() {
+    try {
+      List<String> result = dockerSu("db2pd -");
+
+      for (String outLine : result) {
+        if (outLine.contains("-- Active --")) {
+          return true;
+        }
+      }
+      return false;
+    } catch (Throwable t) {
+      return false;
+    }
+  }
+}

--- a/src/main/java/io/ebean/docker/container/ContainerFactory.java
+++ b/src/main/java/io/ebean/docker/container/ContainerFactory.java
@@ -2,6 +2,7 @@ package io.ebean.docker.container;
 
 import io.ebean.docker.commands.ClickHouseContainer;
 import io.ebean.docker.commands.CockroachContainer;
+import io.ebean.docker.commands.Db2Container;
 import io.ebean.docker.commands.ElasticContainer;
 import io.ebean.docker.commands.HanaContainer;
 import io.ebean.docker.commands.MariaDBContainer;
@@ -106,6 +107,10 @@ public class ContainerFactory {
     String cockroachVersion = runWithVersion("cockroach");
     if (cockroachVersion != null) {
       containers.add(CockroachContainer.create(cockroachVersion, properties));
+    }
+    String db2Version = runWithVersion("db2");
+    if (db2Version != null) {
+      containers.add(Db2Container.create(db2Version, properties));
     }
   }
 

--- a/src/test/java/io/ebean/docker/commands/Db2ContainerTest.java
+++ b/src/test/java/io/ebean/docker/commands/Db2ContainerTest.java
@@ -1,0 +1,77 @@
+package io.ebean.docker.commands;
+
+import io.ebean.docker.container.ContainerConfig;
+import io.ebean.docker.container.ContainerFactory;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Properties;
+
+public class Db2ContainerTest {
+
+  @Test
+  public void start() {
+
+    Db2Config config = new Db2Config("latest");
+    config.setContainerName("temp_db2");
+    config.setPort(50050);
+    config.setFastStartMode(true);
+
+    Db2Container container = new Db2Container(config);
+
+    container.startWithCreate();
+    container.startContainerOnly();
+    container.startWithDropCreate();
+
+    container.stopRemove();
+  }
+
+  @Ignore
+  @Test
+  public void viaContainerFactory() {
+
+    Properties properties = new Properties();
+    properties.setProperty("db2.version", "11.5.4.0");
+    properties.setProperty("db2.containerName", "temp_db2");
+    properties.setProperty("db2.port", "50050");
+
+    properties.setProperty("db2.name", "test_roberto");
+    properties.setProperty("db2.user", "test_robino");
+    //properties.setProperty("db2.startMode", "dropCreate");
+    properties.setProperty("db2.createOptions", "USING CODESET UTF-8 TERRITORY DE COLLATE USING IDENTITY PAGESIZE 32768");
+    properties.setProperty("db2.configOptions", "USING STRING_UNITS CODEUNITS32");
+
+    ContainerFactory factory = new ContainerFactory(properties);
+
+    factory.startContainers(s -> System.out.println(">> " + s));
+
+    ContainerConfig config = factory.config("db2");
+
+    try {
+      Connection connection = config.createConnection();
+
+      exeSql(connection, "drop table if exists test_junk2");
+      exeSql(connection, "create table test_junk2 (acol integer)");
+      exeSql(connection, "insert into test_junk2 (acol) values (42)");
+      exeSql(connection, "insert into test_junk2 (acol) values (43)");
+
+      connection.close();
+
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+
+    } finally {
+      factory.stopContainers(s -> System.out.println(">> " + s));
+    }
+  }
+
+  private void exeSql(Connection connection, String sql) throws SQLException {
+    try (PreparedStatement st = connection.prepareStatement(sql)) {
+      System.out.println("executed " + sql);
+      st.execute();
+    }
+  }
+}


### PR DESCRIPTION
Hello Rob,

we begin to use the ebean-test-docker framework now. Really nice tool.

I've added DB2 support in this PR: It uses https://hub.docker.com/r/ibmcom/db2.
The creation of user & db and connectivity-detection is a bit tricky, as it cannot be done via jdbc. (At least I did not figured out, how)
Note: DB2 seems to be very slow. The Db2ContainerTest takes up to 3 minutes. 

cheers
Roland

